### PR TITLE
Fix: названия комнат вместо ID

### DIFF
--- a/extra/Prompts/Common/CommonContext.script
+++ b/extra/Prompts/Common/CommonContext.script
@@ -14,10 +14,6 @@ IF GAME_ROOM_MITA != None THEN
 	SET output = output + f"You are in room: {GAME_ROOM_MITA}, "
 ENDIF
 
-IF GAME_NEAR_OBJECTS != None THEN
-	SET output = output + f"Near objects: {GAME_NEAR_OBJECTS}, "
-ENDIF
-
 IF GAME_ACTUAL_INFO != None THEN
 	SET output = output + f"Other info: {GAME_ACTUAL_INFO}, "
 ENDIF

--- a/src/controllers/prompt_controller.py
+++ b/src/controllers/prompt_controller.py
@@ -262,9 +262,26 @@ class PromptController:
         )
 
         try:
+            # Словарь перевода ID комнат в названия (основан на enum Rooms)
+            _ROOM_NAMES = {
+                0: "Kitchen",
+                1: "Main Hall",
+                2: "Bedroom",
+                3: "Toilet",
+                4: "Basement",
+                -1: "Unknown",
+            }
+
+            room_player_id = game_state.get("roomPlayer", -1)
+            room_mita_id = game_state.get("roomMita", -1)
+
+            player_room_str = _ROOM_NAMES.get(room_player_id, f"Room {room_player_id}")
+            mita_room_str = _ROOM_NAMES.get(room_mita_id, f"Room {room_mita_id}")
+
             character.set_variable("GAME_DISTANCE", float(game_state.get("distance", 0.0)))
-            character.set_variable("GAME_ROOM_PLAYER", game_state.get("roomPlayer", -1))
-            character.set_variable("GAME_ROOM_MITA", game_state.get("roomMita", -1))
+            character.set_variable("GAME_ROOM_PLAYER", player_room_str)
+            character.set_variable("GAME_ROOM_MITA", mita_room_str)
+
             character.set_variable("GAME_NEAR_OBJECTS", game_state.get("nearObjects", ""))
             character.set_variable("GAME_ACTUAL_INFO", game_state.get("actualInfo", ""))
         except Exception as e:


### PR DESCRIPTION
**Что сделано:**
- В PromptController.py добавил словарь перевода числовых ID комнат - из списка в enum Rooms в Unity.
- Удалил блок Near objects из CommonContext, так как Near objects теперь выводятся отдельно.

-   - (Сделал в питон, т.к. если сделать в юнити, то всё-равно потребуются множественные правки в питон)