### PR TITLE
[codex] Развязка GUI и backend, ускорение старта full GUI

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -397,9 +397,32 @@ from main_logger import logger
 from PyQt6.QtWidgets import QApplication
 import sys
 
+
+def _consume_startup_mode(argv: list[str]) -> str:
+    mode = str(os.environ.get("NEUROMITA_STARTUP_MODE", "full") or "full").strip().lower()
+    remaining = [argv[0]]
+
+    for arg in argv[1:]:
+        low = str(arg or "").strip().lower()
+        if low == "--gui-only":
+            mode = "gui_only"
+            continue
+        if low.startswith("--startup-mode="):
+            mode = low.split("=", 1)[1] or mode
+            continue
+        remaining.append(arg)
+
+    argv[:] = remaining
+
+    if mode in {"gui-only", "gui_only", "ui-only", "ui_only"}:
+        return "gui_only"
+    return "full"
+
+
 if __name__ == "__main__":
     logger.success("Функция main() запущена")
     try:
+        startup_mode = _consume_startup_mode(sys.argv)
         app = QApplication(sys.argv)
         logger.info("QApplication создан")
 
@@ -414,18 +437,19 @@ if __name__ == "__main__":
 
         # Создаем пустой объект для контроллера
         logger.info("Создаю MainController...")
-        controller = MainController(None)
+        controller = MainController(None, startup_mode=startup_mode)
         logger.info("MainController создан")
 
         # Инициализация сборщика данных для дообучения
-        try:
-            from managers.finetune_collector import FineTuneCollector
-            from managers.generation_input_collector import GenerationInputCollector
-            FineTuneCollector.instance = FineTuneCollector()
-            GenerationInputCollector.instance = GenerationInputCollector()
-            logger.info("FineTuneCollector инициализирован")
-        except Exception as _ft_init_err:
-            logger.warning(f"FineTuneCollector не инициализирован: {_ft_init_err}")
+        if startup_mode == "full":
+            try:
+                from managers.finetune_collector import FineTuneCollector
+                from managers.generation_input_collector import GenerationInputCollector
+                FineTuneCollector.instance = FineTuneCollector()
+                GenerationInputCollector.instance = GenerationInputCollector()
+                logger.info("FineTuneCollector инициализирован")
+            except Exception as _ft_init_err:
+                logger.warning(f"FineTuneCollector не инициализирован: {_ft_init_err}")
     
         logger.info("Создаю MainWindow...")
         main_win = MainWindow(controller.settings)

--- a/src/controllers/gui/base_controller.py
+++ b/src/controllers/gui/base_controller.py
@@ -14,6 +14,14 @@ class BaseController:
     def subscribe_to_events(self):
         pass
 
+    def _backend_enabled(self) -> bool:
+        return bool(getattr(self.main_controller, "backend_enabled", True))
+
+    def _service_or_none(self, name: str):
+        if not self._backend_enabled():
+            return None
+        return getattr(self.main_controller, name, None)
+
     def _ui(self, fn):
         if not callable(fn):
             return

--- a/src/controllers/gui/install_gui_controller.py
+++ b/src/controllers/gui/install_gui_controller.py
@@ -209,9 +209,11 @@ class InstallGuiController(BaseController):
     # backend / окно
     # ------------------------------------------------------------------
     def _get_backend(self):
-        backend = getattr(self.main_controller, "install_controller", None)
+        backend = self._service_or_none("install_controller")
         if backend is not None:
             return backend
+        if not self._backend_enabled():
+            return None
         try:
             from controllers.install_controller import InstallController
             backend = InstallController()

--- a/src/controllers/gui/voice_model_controller.py
+++ b/src/controllers/gui/voice_model_controller.py
@@ -44,7 +44,7 @@ class VoiceModelGuiController(BaseController):
         self.event_bus.subscribe(Events.Audio.SHOW_TRITON_DIALOG, self._on_show_triton_dialog, weak=False)
 
     def _backend(self):
-        return getattr(self.main_controller, "voice_model_controller", None)
+        return self._service_or_none("voice_model_controller")
 
     def _attach_view_to_dialog(self, dialog):
         if not dialog or not hasattr(dialog, "layout") or dialog.layout() is None:
@@ -273,10 +273,12 @@ class VoiceModelGuiController(BaseController):
                 settings.save_settings()
             except Exception:
                 pass
-            try:
-                self.main_controller.audio_controller.current_local_voice_id = new_model_id
-            except Exception:
-                pass
+            audio_controller = self._service_or_none("audio_controller")
+            if audio_controller is not None:
+                try:
+                    audio_controller.current_local_voice_id = new_model_id
+                except Exception:
+                    pass
 
             if self.view and hasattr(self.view, "update_local_voice_combobox"):
                 QTimer.singleShot(0, self.view.update_local_voice_combobox)

--- a/src/controllers/gui/voiceover_controller.py
+++ b/src/controllers/gui/voiceover_controller.py
@@ -231,6 +231,9 @@ class VoiceoverGuiController(BaseController):
         btn.setText(_("Подключиться к Telegram", "Connect Telegram"))
 
     def _maybe_autoconnect_tg(self):
+        if not self._backend_enabled():
+            return
+
         use_voice = self._effective_use_voice()
         method = self._effective_method()
         if not use_voice or method != "TG":
@@ -260,6 +263,17 @@ class VoiceoverGuiController(BaseController):
             return
 
         def apply():
+            if not self._backend_enabled():
+                self._sync_everything(allow_autoload=False)
+                self.event_bus.emit(Events.GUI.SHOW_INFO_MESSAGE, {
+                    "title": _("GUI-only режим", "GUI-only mode"),
+                    "message": _(
+                        "Озвучка недоступна: backend-контроллеры не запущены.",
+                        "Voiceover is unavailable because backend controllers are disabled.",
+                    ),
+                })
+                return
+
             self._ensure_voice_model_name_map()
 
             cur = self._current_model_id_from_settings()
@@ -571,6 +585,9 @@ class VoiceoverGuiController(BaseController):
 
     # ---------- local autoload ----------
     def _maybe_autoload_local_model(self):
+        if not self._backend_enabled():
+            return
+
         if not bool(self._get_setting("LOCAL_VOICE_LOAD_LAST", False)):
             return
 

--- a/src/controllers/gui_controller.py
+++ b/src/controllers/gui_controller.py
@@ -69,9 +69,9 @@ class GuiController:
         self._connect_view_signals()
         logger.info("GuiController подписался на события")
 
-        QTimer.singleShot(100, self.system_controller.check_and_install_ffmpeg)
-
-        QTimer.singleShot(500, self.voiceover_controller.autoload_last_model_on_startup)
+        if bool(getattr(self.main_controller, "backend_enabled", True)):
+            QTimer.singleShot(100, self.system_controller.check_and_install_ffmpeg)
+            QTimer.singleShot(500, self.voiceover_controller.autoload_last_model_on_startup)
 
     def _connect_view_signals(self):
         if self.view:

--- a/src/controllers/gui_fallback_controller.py
+++ b/src/controllers/gui_fallback_controller.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from core.events import Event, Events, get_event_bus
+
+
+class GuiFallbackController:
+    """
+    Provides stable read-only answers for GUI queries when backend controllers
+    are intentionally not started.
+    """
+
+    _VOICE_MODEL_FALLBACK_DESCRIPTION = (
+        "GUI-only mode is active. Backend voice services are not started."
+    )
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.event_bus = get_event_bus()
+        self._subscribe_to_events()
+
+    def _subscribe_to_events(self) -> None:
+        eb = self.event_bus
+
+        eb.subscribe(Events.Character.GET_ALL, self._on_get_character_list, weak=False)
+        eb.subscribe(Events.Character.GET, self._on_get_character, weak=False)
+        eb.subscribe(Events.Character.GET_CURRENT_PROFILE, self._on_get_current_profile, weak=False)
+        eb.subscribe(Events.Character.GET_CURRENT_NAME, self._on_get_current_name, weak=False)
+        eb.subscribe(Events.Character.SET_CURRENT, self._on_set_current_character, weak=False)
+
+        eb.subscribe(Events.ApiPresets.GET_PRESET_LIST, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.ApiPresets.GET_CURRENT_PRESET_ID, self._on_get_current_preset_id, weak=False)
+        eb.subscribe(Events.ApiPresets.SET_CURRENT_PRESET_ID, self._on_set_current_preset_id, weak=False)
+
+        eb.subscribe(Events.Model.GET_DEBUG_INFO, self._on_get_debug_info, weak=False)
+        eb.subscribe(Events.Model.GET_TOKEN_STATS, self._on_get_token_stats, weak=False)
+        eb.subscribe(Events.Model.GET_CURRENT_CONTEXT_TOKENS, self._on_get_zero, weak=False)
+        eb.subscribe(Events.Model.CALCULATE_COST, self._on_get_empty_dict, weak=False)
+        eb.subscribe(Events.Model.SCHEDULE_G4F_UPDATE, self._on_schedule_update, weak=False)
+
+        eb.subscribe(Events.Server.GET_GAME_CONNECTION, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Server.STOP_SERVER, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Telegram.GET_SILERO_STATUS, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Telegram.START_SILERO, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Telegram.STOP_SILERO, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Speech.GET_MIC_STATUS, self._on_noop_false, weak=False)
+
+        eb.subscribe(Events.Capture.GET_SCREEN_CAPTURE_STATUS, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Capture.GET_CAMERA_CAPTURE_STATUS, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Capture.CAPTURE_SCREEN, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.Capture.GET_CAMERA_FRAMES, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.Capture.STOP_SCREEN_CAPTURE, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Capture.STOP_CAMERA_CAPTURE, self._on_noop_true, weak=False)
+
+        eb.subscribe(Events.VoiceModel.GET_MODEL_DATA, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.VoiceModel.GET_INSTALLED_MODELS, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.VoiceModel.GET_DEPENDENCIES_STATUS, self._on_get_empty_dict, weak=False)
+        eb.subscribe(Events.VoiceModel.GET_DEFAULT_DESCRIPTION, self._on_get_voice_model_description, weak=False)
+        eb.subscribe(Events.VoiceModel.GET_MODEL_DESCRIPTION, self._on_get_voice_model_description, weak=False)
+
+        eb.subscribe(Events.Audio.GET_ALL_LOCAL_MODEL_CONFIGS, self._on_get_empty_list, weak=False)
+        eb.subscribe(Events.Audio.CHECK_MODEL_INITIALIZED, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Audio.SELECT_VOICE_MODEL, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Audio.INIT_VOICE_MODEL, self._on_noop_false, weak=False)
+        eb.subscribe(Events.Audio.DELETE_SOUND_FILES, self._on_noop_true, weak=False)
+
+        eb.subscribe(Events.Chat.SEND_MESSAGE, self._on_chat_send_message, weak=False)
+        eb.subscribe(Events.Chat.CLEAR_CHAT, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Chat.STAGE_IMAGE, self._on_noop_true, weak=False)
+        eb.subscribe(Events.Chat.CLEAR_STAGED_IMAGES, self._on_noop_true, weak=False)
+
+    def _on_get_character_list(self, _event: Event):
+        current = self._current_character_id()
+        return [current] if current else []
+
+    def _on_get_character(self, _event: Event):
+        character_id = self._current_character_id()
+        if not character_id:
+            return {}
+        return {"char_id": character_id, "name": character_id}
+
+    def _on_get_current_profile(self, _event: Event):
+        character_id = self._current_character_id()
+        if not character_id:
+            return {}
+        return {"character_id": character_id, "name": character_id}
+
+    def _on_get_current_name(self, _event: Event):
+        return self._current_character_id()
+
+    def _on_get_current_preset_id(self, _event: Event):
+        return self.settings.get("LAST_API_PRESET_ID", 0) if self.settings else 0
+
+    def _on_set_current_preset_id(self, event: Event):
+        if not self.settings:
+            return False
+        data = event.data or {}
+        preset_id = data.get("id")
+        if preset_id is None:
+            return False
+        self.settings.set("LAST_API_PRESET_ID", int(preset_id))
+        self.settings.save_settings()
+        return True
+
+    def _on_get_debug_info(self, _event: Event):
+        return "GUI-only mode: backend controllers are disabled."
+
+    def _on_get_token_stats(self, _event: Event):
+        return {}
+
+    def _on_get_zero(self, _event: Event):
+        return 0
+
+    def _on_get_empty_dict(self, _event: Event):
+        return {}
+
+    def _on_get_empty_list(self, _event: Event):
+        return []
+
+    def _on_get_voice_model_description(self, _event: Event):
+        return self._VOICE_MODEL_FALLBACK_DESCRIPTION
+
+    def _on_schedule_update(self, _event: Event):
+        self.event_bus.emit(Events.GUI.SHOW_INFO_MESSAGE, {
+            "title": "GUI-only mode",
+            "message": "Update scheduling is disabled because backend controllers are not started.",
+        })
+        return False
+
+    def _on_chat_send_message(self, _event: Event):
+        self.event_bus.emit(Events.GUI.SHOW_INFO_MESSAGE, {
+            "title": "GUI-only mode",
+            "message": "Message processing is unavailable because backend controllers are disabled.",
+        })
+        return False
+
+    def _on_set_current_character(self, event: Event):
+        if not self.settings:
+            return False
+        data = event.data or {}
+        character_id = str(data.get("character_id") or "").strip()
+        if not character_id:
+            return False
+        self.settings.set("CHARACTER", character_id)
+        self.settings.save_settings()
+        self.event_bus.emit(Events.Character.CURRENT_CHANGED, {
+            "character_id": character_id,
+            "character_name": character_id,
+        })
+        return True
+
+    def _current_character_id(self) -> str:
+        if not self.settings:
+            return ""
+        return str(self.settings.get("CHARACTER", "") or "").strip()
+
+    def _on_noop_true(self, _event: Event):
+        return True
+
+    def _on_noop_false(self, _event: Event):
+        return False

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -176,6 +176,11 @@ class MainController:
     def update_view(self, view):
         if not self.gui_controller:
             self.view = view
+            try:
+                setattr(view, "backend_enabled", bool(self.backend_enabled))
+                setattr(view, "startup_mode", self.startup_mode)
+            except Exception:
+                pass
             self.gui_controller = GuiController(self, view)
             logger.notify("GuiController успешно инициализирован.")
             if self.backend_enabled:

--- a/src/controllers/main_controller.py
+++ b/src/controllers/main_controller.py
@@ -1,53 +1,31 @@
 import os
 import time
-from pathlib import Path
-from PyQt6.QtCore import QTimer
 
+from controllers.gui_fallback_controller import GuiFallbackController
 from controllers.gui_controller import GuiController
-from controllers.audio_controller import AudioController
-from controllers.telegram_controller import TelegramController
-from controllers.capture_controller import CaptureController
-from controllers.model_controller import ModelController
-from controllers.character_controller import CharacterController
-from controllers.speech_controller import SpeechController
 from controllers.settings_controller import SettingsController
-from controllers.chat_controller import ChatController
-from controllers.loop_controller import LoopController
-from controllers.task_controller import TaskController
-from controllers.api_presets_controller import ApiPresetsController
-from controllers.embedding_presets_controller import EmbeddingPresetsController
-from controllers.local_voice_controller import LocalVoiceController
-from controllers.prompt_controller import PromptController
-from controllers.history_controller import HistoryController
-from controllers.graph_controller import GraphController
-from controllers.voice_model_controller import VoiceModelController
-from controllers.install_controller import InstallController
-from controllers.installable_controller import InstallableController
-from controllers.protocols_controller import ProtocolsController
-from controllers.embedding_controller import EmbeddingController
-from controllers.ai_engine_controller import AIEngineController
 
 from main_logger import logger
-from utils.ffmpeg_installer import install_ffmpeg
 from utils.pip_installer import PipInstaller
 from core.events import get_event_bus, Events, Event, shutdown_event_bus
 
-from controllers.server_controller import ServerController
-
 
 class MainController:
-    def __init__(self, view):
+    def __init__(self, view, startup_mode: str = "full"):
         self.view = view
         self.event_bus = get_event_bus()
+        self.startup_mode = self._normalize_startup_mode(startup_mode)
+        self.backend_enabled = self.startup_mode == "full"
 
         self.dialog_active = False
+        self.gui_fallback_controller = None
+        self.loop_controller = None
 
-        self.loop_controller = LoopController()
         logger.notify("LoopController успешно инициализирован.")
 
         self.gui_controller = None
 
-        self.telegram_controller = TelegramController()
+        self.telegram_controller = None
         logger.notify("TelegramController успешно инициализирован.")
 
         try:
@@ -60,6 +38,41 @@ class MainController:
         except Exception as e:
             logger.info("Не удалось удачно получить из системных переменных все данные", e)
             self.settings = SettingsController("Settings/settings.json").settings
+
+        if not self.backend_enabled:
+            self.gui_fallback_controller = GuiFallbackController(self.settings)
+            logger.notify("GuiFallbackController initialized for GUI-only startup mode.")
+            self._subscribe_to_events()
+            logger.notify("MainController initialized in GUI-only mode.")
+            return
+
+        from controllers.ai_engine_controller import AIEngineController
+        from controllers.api_presets_controller import ApiPresetsController
+        from controllers.audio_controller import AudioController
+        from controllers.capture_controller import CaptureController
+        from controllers.character_controller import CharacterController
+        from controllers.chat_controller import ChatController
+        from controllers.embedding_controller import EmbeddingController
+        from controllers.embedding_presets_controller import EmbeddingPresetsController
+        from controllers.graph_controller import GraphController
+        from controllers.history_controller import HistoryController
+        from controllers.install_controller import InstallController
+        from controllers.installable_controller import InstallableController
+        from controllers.local_voice_controller import LocalVoiceController
+        from controllers.loop_controller import LoopController
+        from controllers.model_controller import ModelController
+        from controllers.prompt_controller import PromptController
+        from controllers.protocols_controller import ProtocolsController
+        from controllers.server_controller import ServerController
+        from controllers.speech_controller import SpeechController
+        from controllers.task_controller import TaskController
+        from controllers.telegram_controller import TelegramController
+        from controllers.voice_model_controller import VoiceModelController
+
+        self.loop_controller = LoopController()
+        logger.notify("LoopController initialized for full startup mode.")
+        self.telegram_controller = TelegramController()
+        logger.notify("TelegramController initialized for full startup mode.")
 
         try:
             self.pip_installer = PipInstaller(
@@ -142,6 +155,13 @@ class MainController:
         self._subscribe_to_events()
         logger.notify("MainController подписался на события")
 
+    @staticmethod
+    def _normalize_startup_mode(startup_mode: str | None) -> str:
+        mode = str(startup_mode or "full").strip().lower()
+        if mode in {"gui-only", "gui_only", "ui-only", "ui_only"}:
+            return "gui_only"
+        return "full"
+
     def _init_server_controller(self):
         # Старый серверный API (ServerControllerOld / server_old.py) удалён —
         # всегда используем новый. Настройка USE_NEW_API больше ни на что не
@@ -149,6 +169,7 @@ class MainController:
         if getattr(self, 'server_controller', None):
             return
 
+        from controllers.server_controller import ServerController
         self.server_controller = ServerController()
         logger.notify("ServerController (новый API) успешно инициализирован.")
 
@@ -157,7 +178,8 @@ class MainController:
             self.view = view
             self.gui_controller = GuiController(self, view)
             logger.notify("GuiController успешно инициализирован.")
-            self.settings_controller.load_api_settings(False)
+            if self.backend_enabled:
+                self.settings_controller.load_api_settings(False)
 
             self.event_bus.emit(Events.GUI.VOICEOVER_REFRESH)
 
@@ -195,10 +217,14 @@ class MainController:
         except Exception as e:
             logger.error(f"Ошибка при остановке сервера: {e}", exc_info=True)
 
-        self.capture_controller.stop_screen_capture_thread()
-        self.capture_controller.stop_camera_capture_thread()
+        capture_controller = getattr(self, "capture_controller", None)
+        if capture_controller is not None:
+            capture_controller.stop_screen_capture_thread()
+            capture_controller.stop_camera_capture_thread()
 
-        self.audio_controller.delete_all_sound_files()
+        audio_controller = getattr(self, "audio_controller", None)
+        if audio_controller is not None:
+            audio_controller.delete_all_sound_files()
 
         try:
             if getattr(self, "ai_engine_controller", None):
@@ -206,7 +232,8 @@ class MainController:
         except Exception as e:
             logger.error(f"Ошибка при остановке AI engine: {e}", exc_info=True)
 
-        self.loop_controller.stop_loop()
+        if self.loop_controller is not None:
+            self.loop_controller.stop_loop()
 
         try:
             shutdown_event_bus()

--- a/src/ui/pages/main_page_registry.py
+++ b/src/ui/pages/main_page_registry.py
@@ -39,5 +39,12 @@ def get_main_page_specs() -> tuple[MainPageSpec, ...]:
     return MAIN_PAGE_SPECS
 
 
+def get_main_page_factory(page_key: str) -> PageFactory | None:
+    for spec in MAIN_PAGE_SPECS:
+        if spec.key == page_key:
+            return spec.factory
+    return None
+
+
 def build_main_pages(window) -> dict[str, QWidget]:
     return {spec.key: spec.factory(window) for spec in MAIN_PAGE_SPECS}

--- a/src/ui/pages/sandbox_page.py
+++ b/src/ui/pages/sandbox_page.py
@@ -246,11 +246,11 @@ class SandboxPage(QWidget):
         self._inspector_expanded_width = 420
         self._inspector_collapsed_width = 56
         self._inspector_tab_indexes = {}
+        self._activation_ticket = 0
 
         self._build_ui()
         self._wire_diagnostics()
         self._sync_host_exports()
-        self.on_activated()
 
     def _sync_host_exports(self):
         self.gui.sandbox_page = self
@@ -837,24 +837,45 @@ class SandboxPage(QWidget):
             safe("camera", lambda: on_off(get("ENABLE_CAMERA_CAPTURE", False)))
 
     # --------- Activation -----------
+    def _schedule_activation_step(self, ticket: int, delay_ms: int, callback) -> None:
+        def _run():
+            if ticket != self._activation_ticket:
+                return
+            if getattr(self.gui, "current_main_page", None) != "sandbox":
+                return
+            try:
+                callback()
+            except Exception:
+                logger.error("Sandbox activation refresh failed", exc_info=True)
+
+        QTimer.singleShot(delay_ms, _run)
+
     def on_activated(self):
-        self._populate_chat_character_combobox()
-        self._populate_model_combobox()
-        self._populate_prompt_pack_combobox()
-        self._refresh_character_avatar()
-        self._refresh_status_values()
         self._sync_toggles_from_settings()
-        self._refresh_memory_summary()
-        self._refresh_context_budget()
         self.apply_panel_visibility()
-        self._refresh_debug_summary()
-        # Sync the status dots (voice / mic / RAG) to their current live state.
-        try:
-            self.gui.update_status_colors()
-        except Exception:
-            pass
-        if self._chat_panel is not None:
-            self._chat_panel.on_activated()
+        self._activation_ticket += 1
+        ticket = self._activation_ticket
+
+        self._schedule_activation_step(ticket, 0, self._populate_chat_character_combobox)
+        self._schedule_activation_step(ticket, 0, self._refresh_character_avatar)
+        self._schedule_activation_step(ticket, 15, self._populate_model_combobox)
+        self._schedule_activation_step(ticket, 30, self._populate_prompt_pack_combobox)
+        self._schedule_activation_step(ticket, 45, self._refresh_status_values)
+        self._schedule_activation_step(ticket, 60, self._refresh_memory_summary)
+        self._schedule_activation_step(ticket, 75, self._refresh_context_budget)
+        self._schedule_activation_step(ticket, 90, self._refresh_debug_summary)
+        self._schedule_activation_step(ticket, 105, lambda: self.gui.update_status_colors())
+        self._schedule_activation_step(
+            ticket,
+            120,
+            lambda: self._chat_panel.on_activated() if self._chat_panel is not None else None,
+        )
+        self._schedule_activation_step(
+            ticket,
+            135,
+            lambda: self._character_state_panel.refresh(rebuild=True)
+            if getattr(self, "_character_state_panel", None) is not None else None,
+        )
 
     def show_debug_tab(self):
         if self._inspector_collapsed:

--- a/src/ui/widgets/character_state_panel.py
+++ b/src/ui/widgets/character_state_panel.py
@@ -268,7 +268,6 @@ class CharacterStatePanel(QWidget):
         except Exception:
             pass
 
-        self.refresh(rebuild=True)
 
     # ─────────────────────────────────────────────────────────────
     def _on_toggle_all(self, checked: bool) -> None:

--- a/src/ui/widgets/chat_panel.py
+++ b/src/ui/widgets/chat_panel.py
@@ -34,7 +34,6 @@ class ChatPanel(QWidget):
 
         self._build_ui()
         self.gui.chat_panel = self
-        self.on_activated()
 
     def _get_current_character_id(self) -> str:
         try:
@@ -254,16 +253,10 @@ def update_send_button_state(gui):
 
     has_text = bool(gui.user_entry.toPlainText().strip())
     has_images = bool(getattr(gui, "staged_image_data", []))
-
-    has_auto_images = False
-    if gui._get_setting("AUTO_ATTACH_IMAGES", False):
-        frames = gui.event_bus.emit_and_wait(Events.Capture.CAPTURE_SCREEN, {"limit": 1}, timeout=0.5)
-        has_auto_images = bool(frames and frames[0])
-
-    if gui._get_setting("ENABLE_CAMERA_CAPTURE", False):
-        camera_frames = gui.event_bus.emit_and_wait(Events.Capture.GET_CAMERA_FRAMES, {"limit": 1}, timeout=0.5)
-        has_auto_images = has_auto_images or bool(camera_frames and camera_frames[0])
-
+    has_auto_images = bool(
+        gui._get_setting("AUTO_ATTACH_IMAGES", False)
+        or gui._get_setting("ENABLE_CAMERA_CAPTURE", False)
+    )
     gui.send_button.setEnabled(has_text or has_images or has_auto_images)
     gui.send_button.setToolTip(_("Отправить сообщение", "Send message"))
 

--- a/src/ui/widgets/chat_panel.py
+++ b/src/ui/widgets/chat_panel.py
@@ -247,6 +247,11 @@ def update_send_button_state(gui):
     if not getattr(gui, "user_entry", None) or not getattr(gui, "send_button", None):
         return
 
+    if not bool(getattr(gui, "backend_enabled", True)):
+        gui.send_button.setEnabled(False)
+        gui.send_button.setToolTip(_("Бэкенд отключён в режиме gui-only", "Backend is disabled in gui-only mode"))
+        return
+
     has_text = bool(gui.user_entry.toPlainText().strip())
     has_images = bool(getattr(gui, "staged_image_data", []))
 
@@ -260,6 +265,7 @@ def update_send_button_state(gui):
         has_auto_images = has_auto_images or bool(camera_frames and camera_frames[0])
 
     gui.send_button.setEnabled(has_text or has_images or has_auto_images)
+    gui.send_button.setToolTip(_("Отправить сообщение", "Send message"))
 
 
 def init_image_preview(gui):

--- a/src/ui/windows/app_window_base.py
+++ b/src/ui/windows/app_window_base.py
@@ -204,7 +204,7 @@ class AppWindowBase(QMainWindow):
         self.prepare_stream_signal.connect(self._on_stream_start)
         self.finish_stream_signal.connect(self._on_stream_finish)
 
-        self.update_status_colors()
+        QTimer.singleShot(0, self.update_status_colors)
         QTimer.singleShot(1000, self._check_eula_and_guide)
 
         self.last_voice_model_selected = None

--- a/src/ui/windows/app_window_base.py
+++ b/src/ui/windows/app_window_base.py
@@ -180,12 +180,10 @@ class AppWindowBase(QMainWindow):
         self.hide_status_signal.connect(self._hide_status_slot)
         self.pulse_error_signal.connect(self._pulse_error_slot)
 
+        self.settings_animation = None
         self.setup_ui()
         self.chat_delegate = ChatMessageDelegate()
-        
-        self.settings_animation = QPropertyAnimation(self.settings_overlay, b"maximumWidth")
-        self.settings_animation.setDuration(250)
-        self.settings_animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+        self._ensure_settings_animation()
 
         self.chat_window.installEventFilter(self)
 
@@ -210,6 +208,22 @@ class AppWindowBase(QMainWindow):
         self.last_voice_model_selected = None
         self.current_local_voice_id = None
         self.model_loading_cancelled = False
+
+    def _ensure_settings_animation(self):
+        target = getattr(self, "settings_overlay", None) or self.centralWidget()
+        if target is None:
+            return None
+
+        if self.settings_animation is None:
+            self.settings_animation = QPropertyAnimation(target, b"maximumWidth")
+            self.settings_animation.setDuration(250)
+            self.settings_animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+            return self.settings_animation
+
+        if self.settings_animation.targetObject() is not target:
+            self.settings_animation.stop()
+            self.settings_animation.setTargetObject(target)
+        return self.settings_animation
 
     def _window_specs(self) -> dict:
         return {

--- a/src/ui/windows/main_window.py
+++ b/src/ui/windows/main_window.py
@@ -71,6 +71,7 @@ class MainWindow(AppWindowBase):
         page = factory(self)
         self.page_map[page_key] = page
         self.page_stack.addWidget(page)
+        self._ensure_settings_animation()
         return page
 
     def _init_settings_containers(self):
@@ -84,12 +85,13 @@ class MainWindow(AppWindowBase):
         if page is not None:
             page.show_overview()
         try:
-            self.settings_animation.finished.disconnect(self._on_hide_animation_finished)
+            if self.settings_animation is not None:
+                self.settings_animation.finished.disconnect(self._on_hide_animation_finished)
         except TypeError:
             pass
 
     def show_settings_category(self, category, *, force: bool = False, subsection=None):
-        page = getattr(self, "settings_page", None)
+        page = self._ensure_main_page("settings")
         if page is not None:
             page.show_category(category, force=force, subsection=subsection)
 

--- a/src/ui/windows/main_window.py
+++ b/src/ui/windows/main_window.py
@@ -3,7 +3,7 @@ from PyQt6.QtWidgets import QFrame, QHBoxLayout, QStackedWidget, QVBoxLayout, QW
 from styles.main_styles import get_stylesheet
 from ui.pages.home_page import build_home_page
 from ui.pages.logs_page import build_logs_page
-from ui.pages.main_page_registry import MAIN_PAGE_ORDER, build_main_pages
+from ui.pages.main_page_registry import MAIN_PAGE_ORDER, get_main_page_factory
 from ui.pages.news_page import build_news_page
 from ui.pages.news_support import get_news_content as load_news_content
 from ui.pages.news_support import get_news_releases as load_news_releases
@@ -48,17 +48,30 @@ class MainWindow(AppWindowBase):
         content_layout.addWidget(self.page_stack)
         main_layout.addWidget(content_host, 1)
 
-        self.page_map = build_main_pages(self)
-        for key in MAIN_PAGE_ORDER:
-            self.page_stack.addWidget(self.page_map[key])
+        self.page_map = {}
 
         try:
             apply_section_visibility(self)
         except Exception:
             pass
 
+        self._ensure_main_page("sandbox")
         self.switch_main_page("sandbox")
         self.resize(1560, 920)
+
+    def _ensure_main_page(self, page_key):
+        page = getattr(self, "page_map", {}).get(page_key)
+        if page is not None:
+            return page
+
+        factory = get_main_page_factory(page_key)
+        if factory is None or not hasattr(self, "page_stack"):
+            return None
+
+        page = factory(self)
+        self.page_map[page_key] = page
+        self.page_stack.addWidget(page)
+        return page
 
     def _init_settings_containers(self):
         page = getattr(self, "settings_page", None)
@@ -81,8 +94,10 @@ class MainWindow(AppWindowBase):
             page.show_category(category, force=force, subsection=subsection)
 
     def switch_main_page(self, page_key):
-        page = getattr(self, "page_map", {}).get(page_key)
-        if page is None or not hasattr(self, "page_stack"):
+        if page_key not in MAIN_PAGE_ORDER or not hasattr(self, "page_stack"):
+            return
+        page = self._ensure_main_page(page_key)
+        if page is None:
             return
         current_page = self.page_stack.currentWidget()
 


### PR DESCRIPTION
﻿## Что сделано

Ветка двигает проект в сторону более слабой связности между GUI и backend и одновременно разгружает старт full GUI.

В PR уже вошло:
- добавление режима `gui-only`, в котором интерфейс может подняться без полного backend-стека;
- fallback-контроллер для безопасных GUI-запросов без реального backend;
- явное состояние `backend_enabled` / `startup_mode` во view и защита части GUI-логики от слепых backend-вызовов;
- ленивое создание основных launcher-страниц вместо полного eager-init на старте;
- отложенная догрузка тяжёлой активации `sandbox`, чтобы окно показывалось раньше, чем закончатся синхронные запросы;
- удаление синхронного polling screen/camera capture из горячего UI-пути обновления кнопки отправки;
- совместимый фикс для lazy settings page, чтобы базовое окно не ожидало готовый `settings_overlay` сразу после `setup_ui()`.

## Зачем это нужно

Цель не в одном локальном фиксe, а в изменении архитектурного направления:
- GUI должен уметь жить отдельно от полного backend;
- full GUI не должен лагать на старте из-за того, что синхронно поднимается всё подряд;
- контроллеры должны быть поставщиками данных и действий, а не обязательным условием для появления интерфейса.

По сути это шаг к схеме "сначала быстро поднять окно, потом дозагружать зависимые части и backend-состояние".

## Что ещё не закончено

PR пока draft, потому что хвост работы ещё есть:
- нужно дочистить оставшиеся `emit_and_wait(...)` в UI-слое, особенно в частых UI-событиях и при первом открытии тяжёлых экранов;
- отдельно стоит разгрузить первую инициализацию `settings_page`;
- нужно формализовать контракт GUI ↔ backend, чтобы fallback-ответы были не набором ad-hoc заглушек, а поддерживаемым runtime-слоем;
- нужно прогнать не только исходники, но и реальную пересборку / запуск `NeuroMita.pyz`, потому что старый артефакт сам не обновится.

## Риски и замечания

- Это архитектурная ветка, а не только UI-косметика: изменения затрагивают порядок инициализации, жизненный цикл страниц и поведение GUI без backend.
- При выборе base `releases` diff остаётся узким и соответствует именно этой задаче. Против `main` сюда затянется несвязанная история, поэтому PR открывается в `releases`.
- В репозитории добавлен отдельный поясняющий документ: `docs/plans/gui_runtime_decouple_draft_ru.md`.

## Проверка

Сделано на текущем этапе:
- базовая проверка синтаксиса изменённых Python-файлов через `ast.parse`;
- проверка истории и целевой базы ветки перед открытием PR.

Не сделано в рамках этого PR:
- полный runtime smoke-тест;
- пересборка и прогон свежего `NeuroMita.pyz`.
